### PR TITLE
Correct issue with cleaning reservations/node stats

### DIFF
--- a/bin/nova_database_prune.py
+++ b/bin/nova_database_prune.py
@@ -75,9 +75,9 @@ try:
     db.autocommit(False)
     cursor = db.cursor(MySQLdb.cursors.DictCursor)
     cursor.execute("""DELETE FROM reservations WHERE expire
-                    < DATE_SUB(NOW(), INTERVAL %s day)""")
+                    < DATE_SUB(NOW(), INTERVAL %s day)""" % days)
     cursor.execute("""DELETE FROM compute_node_stats WHERE deleted_at
-                    < DATE_SUB(NOW(), INTERVAL %s day)""")
+                    < DATE_SUB(NOW(), INTERVAL %s day)""" % days)
     db.commit()
 except db.Error, e:
     print "Rollback %s %s" % (e[0], e[1])


### PR DESCRIPTION
days was not being passed to the deletes so they were failing.
