### PR TITLE
nova_sync_quotas: add verbosity and bug fix

### DIFF
--- a/bin/nova_sync_quotas.py
+++ b/bin/nova_sync_quotas.py
@@ -12,6 +12,8 @@ tenant_group.add_argument('--tenant', action='append', default=[],
                           help='Tenant(s) to work on')
 tenant_group.add_argument('--all', action='store_true', default=False,
                           help='Work on ALL tenants')
+parser.add_argument('--noop', '-n', action='store_true', default=False,
+                    help='No-Op (just report)')
 parser.add_argument('--verbose', '-v', action='count', default=0,
                     help='Verbose')
 parser.add_argument('--config', '-c', action='store', dest='config_file',
@@ -66,13 +68,22 @@ for u in initial_usages:
                                                   'ram': 0}
     initial_usage[u.project_id][u.user_id][u.resource] = u.in_use
 
+if args.verbose >= 2:
+    for i in initial_usage:
+        print "reported quota usage for %s: %s" % (i, initial_usage[i])
+
 # preload dict(usage) so that we iterate over projects with zero VMs
-usage = initial_usage
+usage = dict()
+for project in initial_usage:
+    for user in initial_usage[project]:
+        usage[project] = {user: {'instances': 0, 'cores': 0, 'ram': 0}}
 
 # These are the only states that should count against one's quota
 instance_select = select([instances]).where(or_(instances.c.vm_state == 'active',
                                                 instances.c.vm_state == 'suspended',
                                                 instances.c.vm_state == 'paused',
+                                                instances.c.vm_state == 'error',
+                                                instances.c.vm_state == 'stopped',
                                                 instances.c.vm_state == 'shutoff'))
 instances = conn.execute(instance_select)
 for i in instances:
@@ -82,15 +93,24 @@ for i in instances:
     if project_id not in usage:
         usage[project_id] = dict()
     if i.user_id not in usage[project_id]:
+        if args.verbose >= 2:
+            print "initializing %s usage to instance=0, cores=0, ram=0" % i.user_id
         usage[project_id][i.user_id] = {'instances': 0, 'cores': 0, 'ram': 0}
     usage[project_id][i.user_id]['ram'] += getattr(i, 'memory_mb')
     usage[project_id][i.user_id]['instances'] += 1
     usage[project_id][i.user_id]['cores'] += i.vcpus
 
+if args.verbose >= 2:
+    for i in usage:
+        print "determined usage for %s: %s" % (i, usage[i])
+
 for project in usage:
     for user in usage[project]:
         if project not in initial_usage:
             initial_usage[project] = dict()
+        if args.verbose >= 2:
+            print "%s reported usage: %s" % (project, initial_usage[project])
+            print "%s actual usage: %s" % (project, usage[project])
         if user not in initial_usage[project]:
             initial_usage[project][user] = {'instances': 0,
                                             'cores': 0,
@@ -105,19 +125,28 @@ for project in usage:
                 where(quota_usages.c.user_id == user).\
                 where(quota_usages.c.resource == 'instances').\
                 values(in_use=usage[project][user]['instances'])
-            conn.execute(update)
+            if args.noop:
+                print "Not actually updating %s instances" % project
+            else:
+                conn.execute(update)
             update = quota_usages.update().\
                 where(quota_usages.c.project_id == project).\
                 where(quota_usages.c.user_id == user).\
                 where(quota_usages.c.resource == 'cores').\
                 values(in_use=usage[project][user]['cores'])
-            conn.execute(update)
+            if args.noop:
+                print "Not actually updating %s cores" % project
+            else:
+                conn.execute(update)
             update = quota_usages.update().\
                 where(quota_usages.c.project_id == project).\
                 where(quota_usages.c.user_id == user).\
                 where(quota_usages.c.resource == 'ram').\
                 values(in_use=usage[project][user]['ram'])
-            conn.execute(update)
+            if args.noop:
+                print "Not actually updating %s ram" % project
+            else:
+                conn.execute(update)
         else:
             if args.verbose >= 1:
                 print "project {}, user {} already synced".format(project,


### PR DESCRIPTION
- Added additional print statements for verbose mode
- Added a noop mode, which does everything but update the database
- Fix a bug where the usage dict was being improperly populated
- Fix a bug where we weren't counting all the VMs we should be to determine
  current quota usage