### PR TITLE
Catch python2 exceptions

### DIFF
--- a/bin/nova_audit_routers.py
+++ b/bin/nova_audit_routers.py
@@ -43,7 +43,7 @@ def get_os_vars():
             config = ConfigParser.ConfigParser()
             config.read(['os.cfg', os.path.expanduser('~/.os.cfg')])
             os_vars[os_var] = config.get('OPENSTACK', os_var.lower())
-        except ConfigParser.NoOptionError:
+        except (ConfigParser.NoOptionError, ConfigParser.NoSectionError):
             continue
 
     for os_var in os_vars.keys():


### PR DESCRIPTION
With python3, the configparser works differently/raises different
exceptions.  Thus, we need to catch 2 types of exceptions in python2.